### PR TITLE
ycb: Remove trailing whitespace in mtl files

### DIFF
--- a/ycb/meshes/003_cracker_box_textured.mtl
+++ b/ycb/meshes/003_cracker_box_textured.mtl
@@ -1,4 +1,4 @@
 newmtl material_0
 # shader_type beckmann
-map_Kd 003_cracker_box_textured.png 
+map_Kd 003_cracker_box_textured.png
 

--- a/ycb/meshes/004_sugar_box_textured.mtl
+++ b/ycb/meshes/004_sugar_box_textured.mtl
@@ -1,4 +1,4 @@
 newmtl material_0
 # shader_type beckmann
-map_Kd 004_sugar_box_textured.png 
+map_Kd 004_sugar_box_textured.png
 

--- a/ycb/meshes/005_tomato_soup_can_textured.mtl
+++ b/ycb/meshes/005_tomato_soup_can_textured.mtl
@@ -1,4 +1,4 @@
 newmtl material_0
 # shader_type beckmann
-map_Kd 005_tomato_soup_can_textured.png 
+map_Kd 005_tomato_soup_can_textured.png
 

--- a/ycb/meshes/006_mustard_bottle_textured.mtl
+++ b/ycb/meshes/006_mustard_bottle_textured.mtl
@@ -1,4 +1,4 @@
 newmtl material_0
 # shader_type beckmann
-map_Kd 006_mustard_bottle_textured.png 
+map_Kd 006_mustard_bottle_textured.png
 

--- a/ycb/meshes/009_gelatin_box_textured.mtl
+++ b/ycb/meshes/009_gelatin_box_textured.mtl
@@ -1,4 +1,4 @@
 newmtl material_0
 # shader_type beckmann
-map_Kd 009_gelatin_box_textured.png 
+map_Kd 009_gelatin_box_textured.png
 

--- a/ycb/meshes/010_potted_meat_can_textured.mtl
+++ b/ycb/meshes/010_potted_meat_can_textured.mtl
@@ -1,4 +1,4 @@
 newmtl material_0
 # shader_type beckmann
-map_Kd 010_potted_meat_can_textured.png 
+map_Kd 010_potted_meat_can_textured.png
 


### PR DESCRIPTION
The extra space confuses some of Drake's filename parsing.

Towards https://github.com/RobotLocomotion/drake/issues/13663.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/models/11)
<!-- Reviewable:end -->
