### PR TITLE
[veggies] Fix bump map of the yellow bell pepper

### DIFF
--- a/veggies/yellow_bell_pepper_no_stem_low.mtl
+++ b/veggies/yellow_bell_pepper_no_stem_low.mtl
@@ -5,9 +5,10 @@ newmtl bell_pepper_no_stem_material
 Kd 1 1 1
 Ke 0 0 0
 illum 1
+Ks .25 .25 .25
+Ns 100
 map_Kd bell_pepper_no_stem_color.png
-bump bell_pepper_no_stem_normal.png
-map_bump bell_pepper_no_stem_normal.png
+bump bell_pepper_no_stem_normal.png -bm 0.001
 
 newmtl $Material_1
 Kd 1 1 1


### PR DESCRIPTION
With help from @SeanCurtis-TRI, we fix the visual effect of the bump map of the yellow bell pepper in MeshCat.

These two pictures from MeshCat compare the effect before and after this change.

![image](https://github.com/RobotLocomotion/models/assets/42557859/8680f86d-f73d-4c37-9a36-c445f97f1d97)

![image](https://github.com/RobotLocomotion/models/assets/42557859/44d46115-f059-4427-9343-604614bcf428)


The companion Drake PR is https://github.com/RobotLocomotion/drake/pull/20485.  From that Drake PR, you can run Drake with:
```
drake $ bazel run //examples/hydroelastic/python_nonconvex_mesh:drop_pepper_py -- --simulation_time=0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/models/27)
<!-- Reviewable:end -->
