### PR TITLE
Clean up some non-conforming URDF elements

### DIFF
--- a/atlas/robotiq.urdf
+++ b/atlas/robotiq.urdf
@@ -1024,12 +1024,12 @@ s-model_articulated - articulated version of the robotiq s-model,
         <color rgba="0 1 1 1"/>
       </material>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="1.3"/>
+      <inertia ixx="0.006012" ixy="0.000079" ixz="-0.00024" iyy="0.012892" iyz="0" izz="0.002435"/>
+    </inertial>
   </link>
-  <inertial>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
-    <mass value="1.3"/>
-    <inertia ixx="0.006012" ixy="0.000079" ixz="-0.00024" iyy="0.012892" iyz="0" izz="0.002435"/>
-  </inertial>
   <joint name="palm_finger_1_joint" type="fixed">
     <parent link="palm"/>
     <child link="finger_1_link_0"/>

--- a/atlas/robotiq_simple.urdf
+++ b/atlas/robotiq_simple.urdf
@@ -353,12 +353,12 @@
         <color rgba="0 1 1 1"/>
       </material>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="1.3"/>
+      <inertia ixx="0.006012" ixy="0.000079" ixz="-0.00024" iyy="0.012892" iyz="0" izz="0.002435"/>
+    </inertial>
   </link>
-  <inertial>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
-    <mass value="1.3"/>
-    <inertia ixx="0.006012" ixy="0.000079" ixz="-0.00024" iyy="0.012892" iyz="0" izz="0.002435"/>
-  </inertial>
   <joint name="palm_finger_1_joint" type="fixed">
     <parent link="palm"/>
     <child link="finger_1_link_0"/>

--- a/atlas/robotiq_tendons.urdf
+++ b/atlas/robotiq_tendons.urdf
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="s-model_articulated">
-  <parameter name="spring_stiffness" value="1"/>
   <link name="finger_1_link_0">
     <visual>
       <origin rpy="0 0 0" xyz="0.020 0 0"/>
@@ -399,12 +398,12 @@
         <color rgba="0 1 1 1"/>
       </material>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="1.3"/>
+      <inertia ixx="0.006012" ixy="0.000079" ixz="-0.00024" iyy="0.012892" iyz="0" izz="0.002435"/>
+    </inertial>
   </link>
-  <inertial>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
-    <mass value="1.3"/>
-    <inertia ixx="0.006012" ixy="0.000079" ixz="-0.00024" iyy="0.012892" iyz="0" izz="0.002435"/>
-  </inertial>
   <joint name="palm_finger_1_joint" type="fixed">
     <parent link="palm"/>
     <child link="finger_1_link_0"/>
@@ -445,21 +444,6 @@
     <child link="finger_tensioner"/>
     <limit lower="-0.02" upper="0.1"/>
   </joint>
-  <cable name="finger1_cable" min_length="0.1" max_length="0.1">
-    <terminator link="finger_1_link_3" xyz="0 0 0"/>
-    <!-- <pulley link="finger_1_link_2" xyz="0 0 0" radius="0"/>  -->
-    <terminator link="finger_tensioner" xyz="0 0 0"/>
-  </cable>
-  <cable name="finger2_cable" min_length="0.1" max_length="0.1">
-    <terminator link="finger_2_link_3" xyz="0 0 0"/>
-    <!-- <pulley link="finger_1_link_2" xyz="0 0 0" radius="0"/>  -->
-    <terminator link="finger_tensioner" xyz="0 0 0"/>
-  </cable>
-  <cable name="finger_middle_cable" min_length="0.1" max_length="0.1">
-    <terminator link="finger_middle_link_3" xyz="0 0 0"/>
-    <!-- <pulley link="finger_1_link_2" xyz="0 0 0" radius="0"/>  -->
-    <terminator link="finger_tensioner" xyz="0 0 0"/>
-  </cable>
   <transmission name="gripper" type="SimpleTransmission">
     <actuator name="gripper"/>
     <joint name="finger_tensioner"/>


### PR DESCRIPTION
In anticipation of schema checking for URDF, clean up some structure errors in robotiq models.

* The `cable` element does not obey drake namespace style for extensions, and has not had code support since removal of matlab files in 2017.
* Move some `inertial` elements to their likely intended homes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/models/28)
<!-- Reviewable:end -->
