### PR TITLE
Clean up more non-conforming URDF elements

### DIFF
--- a/atlas/atlas_convex_hull.urdf
+++ b/atlas/atlas_convex_hull.urdf
@@ -1019,9 +1019,6 @@
       <geometry>
         <mesh filename="package://drake_models/atlas/meshes/head_chull.obj"/>
       </geometry>
-      <material name="">
-        <color rgba="0.9098 0.44314 0.031373 1"/>
-      </material>
     </collision>
   </link>
   <link name="pre_spindle"/>
@@ -1135,9 +1132,6 @@
       <geometry>
         <mesh filename="package://drake_models/atlas/meshes/head_camera_chull.obj"/>
       </geometry>
-      <material name="">
-        <color rgba="0.72941 0.35686 0.023529 1"/>
-      </material>
     </collision>
   </link>
   <joint name="head_hokuyo_fixed_joint" type="fixed">

--- a/atlas/robotiq.urdf
+++ b/atlas/robotiq.urdf
@@ -46,9 +46,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow">
-        <color rgba="0 1 1 1"/>
-      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -74,7 +71,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -95,7 +91,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -250,11 +245,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 -0.52" xyz="0.050 -.028 0"/>
     <limit effort="100" lower="-2.111" upper="-0.199" velocity="100"/>
   </joint>
-  <loop_joint name="finger_1_fourbar_0_joint_3" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_1_fourbar_0_link_2" rpy="0 0 0" xyz=".05398 0 0"/>
-    <link2 link="finger_1_fourbar_0_link_3" rpy="0 0 0" xyz=".01473 0 0"/>
-  </loop_joint>
   <joint name="finger_1_fourbar_3_joint_0" type="continuous">
     <axis xyz="0 0 1"/>
     <parent link="finger_1_link_2"/>
@@ -276,11 +266,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <limit effort="100" lower="-1.367" upper="-0.995" velocity="100"/>
   </joint>
-  <loop_joint name="finger_1_fourbar_3_joint_3" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_1_fourbar_3_link_3" rpy="0 0 0" xyz="0.01270 0 0"/>
-    <link2 link="finger_1_fourbar_3_link_2" rpy="0 0 0" xyz="0.03810 0 0"/>
-  </loop_joint>
   <joint name="finger_1_fourbar_linkage_joint_0" type="continuous">
     <axis xyz="0 0 1"/>
     <parent link="finger_1_fourbar_0_link_3"/>
@@ -288,11 +273,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 0" xyz=".01473 0 0"/>
     <limit effort="100" lower="1.4" upper="1.5" velocity="100"/>
   </joint>
-  <loop_joint name="finger_1_fourbar_linkage_joint_1" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_1_fourbar_linkage" rpy="0 0 0" xyz=".015236 0 0"/>
-    <link2 link="finger_1_fourbar_3_link_1" rpy="0 0 0" xyz=".02222 0 0"/>
-  </loop_joint>
   <gazebo reference="finger_1_link_0">
     <material>Gazebo/FlatBlack</material>
     <turnGravityOff>true</turnGravityOff>
@@ -380,7 +360,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -406,7 +385,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -427,7 +405,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -582,11 +559,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 -0.52" xyz="0.050 -.028 0"/>
     <limit effort="100" lower="-2.111" upper="-0.199" velocity="100"/>
   </joint>
-  <loop_joint name="finger_2_fourbar_0_joint_3" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_2_fourbar_0_link_2" rpy="0 0 0" xyz=".05398 0 0"/>
-    <link2 link="finger_2_fourbar_0_link_3" rpy="0 0 0" xyz=".01473 0 0"/>
-  </loop_joint>
   <joint name="finger_2_fourbar_3_joint_0" type="continuous">
     <axis xyz="0 0 1"/>
     <parent link="finger_2_link_2"/>
@@ -608,11 +580,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <limit effort="100" lower="-1.367" upper="-0.995" velocity="100"/>
   </joint>
-  <loop_joint name="finger_2_fourbar_3_joint_3" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_2_fourbar_3_link_3" rpy="0 0 0" xyz="0.01270 0 0"/>
-    <link2 link="finger_2_fourbar_3_link_2" rpy="0 0 0" xyz="0.03810 0 0"/>
-  </loop_joint>
   <joint name="finger_2_fourbar_linkage_joint_0" type="continuous">
     <axis xyz="0 0 1"/>
     <parent link="finger_2_fourbar_0_link_3"/>
@@ -620,11 +587,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 0" xyz=".01473 0 0"/>
     <limit effort="100" lower="1.4" upper="1.5" velocity="100"/>
   </joint>
-  <loop_joint name="finger_2_fourbar_linkage_joint_1" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_2_fourbar_linkage" rpy="0 0 0" xyz=".015236 0 0"/>
-    <link2 link="finger_2_fourbar_3_link_1" rpy="0 0 0" xyz=".02222 0 0"/>
-  </loop_joint>
   <gazebo reference="finger_2_link_0">
     <material>Gazebo/FlatBlack</material>
     <turnGravityOff>true</turnGravityOff>
@@ -712,7 +674,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -738,7 +699,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -759,7 +719,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -914,11 +873,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 -0.52" xyz="0.050 -.028 0"/>
     <limit effort="100" lower="-2.111" upper="-0.199" velocity="100"/>
   </joint>
-  <loop_joint name="finger_middle_fourbar_0_joint_3" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_middle_fourbar_0_link_2" rpy="0 0 0" xyz=".05398 0 0"/>
-    <link2 link="finger_middle_fourbar_0_link_3" rpy="0 0 0" xyz=".01473 0 0"/>
-  </loop_joint>
   <joint name="finger_middle_fourbar_3_joint_0" type="continuous">
     <axis xyz="0 0 1"/>
     <parent link="finger_middle_link_2"/>
@@ -940,11 +894,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <limit effort="100" lower="-1.367" upper="-0.995" velocity="100"/>
   </joint>
-  <loop_joint name="finger_middle_fourbar_3_joint_3" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_middle_fourbar_3_link_3" rpy="0 0 0" xyz="0.01270 0 0"/>
-    <link2 link="finger_middle_fourbar_3_link_2" rpy="0 0 0" xyz="0.03810 0 0"/>
-  </loop_joint>
   <joint name="finger_middle_fourbar_linkage_joint_0" type="continuous">
     <axis xyz="0 0 1"/>
     <parent link="finger_middle_fourbar_0_link_3"/>
@@ -952,11 +901,6 @@ s-model_articulated - articulated version of the robotiq s-model,
     <origin rpy="0 0 0" xyz=".01473 0 0"/>
     <limit effort="100" lower="1.4" upper="1.5" velocity="100"/>
   </joint>
-  <loop_joint name="finger_middle_fourbar_linkage_joint_1" type="continuous">
-    <axis xyz="0 0 1"/>
-    <link1 link="finger_middle_fourbar_linkage" rpy="0 0 0" xyz=".015236 0 0"/>
-    <link2 link="finger_middle_fourbar_3_link_1" rpy="0 0 0" xyz=".02222 0 0"/>
-  </loop_joint>
   <gazebo reference="finger_middle_link_0">
     <material>Gazebo/FlatBlack</material>
     <turnGravityOff>true</turnGravityOff>
@@ -1020,9 +964,6 @@ s-model_articulated - articulated version of the robotiq s-model,
       <geometry>
         <box size=".1 .01 .1"/>
       </geometry>
-      <material name="yellow">
-        <color rgba="0 1 1 1"/>
-      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>

--- a/atlas/robotiq_simple.urdf
+++ b/atlas/robotiq_simple.urdf
@@ -29,9 +29,6 @@
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow">
-        <color rgba="0 1 1 1"/>
-      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -57,7 +54,6 @@
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -78,7 +74,6 @@
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -145,7 +140,6 @@
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -171,7 +165,6 @@
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -192,7 +185,6 @@
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -259,7 +251,6 @@
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -285,7 +276,6 @@
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -306,7 +296,6 @@
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -349,9 +338,6 @@
       <geometry>
         <box size=".1 .01 .1"/>
       </geometry>
-      <material name="yellow">
-        <color rgba="0 1 1 1"/>
-      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>

--- a/atlas/robotiq_tendons.urdf
+++ b/atlas/robotiq_tendons.urdf
@@ -29,9 +29,6 @@
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow">
-        <color rgba="0 1 1 1"/>
-      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -57,7 +54,6 @@
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -78,7 +74,6 @@
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -139,7 +134,6 @@
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -165,7 +159,6 @@
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -186,7 +179,6 @@
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -256,7 +248,6 @@
       <geometry>
         <box size=".028 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -282,7 +273,6 @@
       <geometry>
         <box size=".018 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -303,7 +293,6 @@
       <geometry>
         <box size=".025 .01 .03"/>
       </geometry>
-      <material name="yellow"/>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -394,9 +383,6 @@
       <geometry>
         <box size=".1 .01 .1"/>
       </geometry>
-      <material name="yellow">
-        <color rgba="0 1 1 1"/>
-      </material>
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>


### PR DESCRIPTION
These changes track further updates in the development of the drake urdf schema.

* collision/material is not a thing.
* loop_joint is a long-abandoned drake-specific tag.

Per https://drake.mit.edu/model_version_control.html, matching Drake PR is TBD.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/models/30)
<!-- Reviewable:end -->
