### PR TITLE
Fix typo in plate_8in.gltf at the uri to plate_8in.bin

### DIFF
--- a/dishes/assets/plate_8in.gltf
+++ b/dishes/assets/plate_8in.gltf
@@ -75,7 +75,7 @@
     {
       "name": "plate_8in_col",
       "byteLength": 25920,
-      "uri": "plate_8in_col.bin"
+      "uri": "plate_8in.bin"
     }
   ],
   "bufferViews": [


### PR DESCRIPTION
Fix typo in plate_8in.gltf

Twin PR: https://github.com/RobotLocomotion/drake/pull/21442

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/models/67)
<!-- Reviewable:end -->
